### PR TITLE
Restore continuous action to working state

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,5 @@ jobs:
          uses: actions/checkout@v2
        - name: alr2appimage-action
          uses: mgrojo/alr2appimage-action@main
+         with:
+             alireVersion: "nightly"

--- a/alire.toml
+++ b/alire.toml
@@ -20,7 +20,7 @@ generate_C = false
 
 [[depends-on]]
 ansiada = "^1.0.0"
-## gnat="^15.1.2"
+gnat="^14"
 
 [[test]]
 command = ["make", "build", "check"]


### PR DESCRIPTION
Update Alire version to support `[test]` and downgrade GNAT version, as the recently released 15 version has an issue with the source code.